### PR TITLE
mkdocs plugin

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -36,3 +36,4 @@ jobs:
         if: steps.check_file_changed.outputs.docs_changed == 'True' || ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-include-dir-to-nav


### PR DESCRIPTION
Want to use mkdocs-include-dir-to-nav to being able to glob a sub dir and not have to manually add stuff to mkdocs links.