### PR TITLE
Better configuration + Intermixed Thread Lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] Improved Configuration Property
+
+The configuration propertynow supports sub keys to improve filtering.
+
+This also includes a fix to handle multiple threads being mixed.
+
 ## [0.2.0] Formatting
 
 This adds a ChocoLog specific format. The goal is to show relevant info such as

--- a/ChocoLogParse/ChocoLogParse.psd1
+++ b/ChocoLogParse/ChocoLogParse.psd1
@@ -12,7 +12,7 @@
   RootModule = 'ChocoLogParse.psm1'
 
   # Version number of this module.
-  ModuleVersion = '0.2.0'
+  ModuleVersion = '0.3.0'
 
   # Supported PSEditions
   # CompatiblePSEditions = @()

--- a/ChocoLogParse/Classes/ChocoLog.ps1
+++ b/ChocoLogParse/Classes/ChocoLog.ps1
@@ -34,52 +34,57 @@ class ChocoLog : Log4NetLog {
 
     # Detect known patterns
     $this.logs | ForEach-Object {
-      $message = $_.message
-      # Command Line Pattern
-      $cliPattern = 'Command line: '
-      if ($message.StartsWith($cliPattern)) {
-        $this.cli = $message -replace $cliPattern
+      switch ($_.message) {
+        { $_.StartsWith('Command line: ') } { $this.SetCli($_) }
+        { $_.StartsWith('Exiting with ') } { $this.SetExitCode($_) }
+        { $_.StartsWith('Configuration:') } {
+          $this.ParseConfiguration($_)
+        }
+        Default {}
       }
 
-      # Exit code Pattern
-      $exitPattern = 'Exiting with '
-      if ($message.StartsWith($exitPattern)) {
-        $this.exitCode = $message -replace $exitPattern
-      }
+    }
+  }
 
-      # Configuration pattern
-      $configPattern = "Configuration:"
-      if ($message.StartsWith($configPattern)) {
-        $arr = $message -replace 'Configuration: ' -replace "`n" -split "\|" | Where-Object {
-          -Not [string]::IsNullOrWhiteSpace($_)
+  [void] SetCli($message) {
+    $this.cli = $message -replace 'Command line: '
+  }
+
+  [void] SetExitCode($message) {
+    $this.exitCode = $message -replace 'Exiting with '
+  }
+
+  [void] ParseConfiguration($message) {
+    $clean = $message -replace 'Configuration: ' -replace "`n"
+    $entries = $clean -split "\|" | Where-Object {
+      -Not [string]::IsNullOrWhiteSpace($_)
+    }
+
+    $configHash = @{}
+
+    foreach ($entry in $entries) {
+      # Split on the `=`
+      # example: Features.UseEnhancedExitCodes='False'
+      $k, $v = $entry -split '='
+      $key = $k.Trim()
+      $value = ($v -join '').Trim(" ", "'")
+
+      # Let's treat foo.bar and a subkey because I'm a masochist
+      if ($key.Contains(".")) {
+        # AFAICT there is only ever one subkey
+        # WARNING: Split is doing regex so you have to escape the period.
+        $parent, $subkey = $key.Split('.')
+
+        if (-Not $configHash.ContainsKey($parent)) {
+          $configHash[$parent] = @{}
         }
 
-        foreach ($entry in $arr) {
-          # Split on the `=`
-          # example: Features.UseEnhancedExitCodes='False'
-          $k, $v = $entry -split '='
-          $key = $k.Trim()
-          $value = ($v -join '').Trim(" ", "'")
-
-          # Let's treat foo.bar and a subkey because I'm a masochist
-          if ($key.Contains('.')) {
-            # AFAICT there is only ever one subkey
-            # WARNING: Split is doing regex so you have to escape the period.
-            $parent, $subkey = $key.Split('.')
-
-            if (-Not $this.Configuration($parent)) {
-              $this.Configuration[$parent] = @{}
-            }
-
-            $this.Configuration[$parent][$subkey] = $value
-
-          } else {
-            # Top level key, keep it simple
-            $this.Configuration[$key] = $value
-          }
-
-        }
+        $configHash[$parent][$subkey] = $value
+      } else {
+        # Top level key, keep it simple
+        $configHash[$key] = $value
       }
     }
+    $this.Configuration = $configHash
   }
 }

--- a/ChocoLogParse/Public/Read-ChocoLog.ps1
+++ b/ChocoLogParse/Public/Read-ChocoLog.ps1
@@ -77,6 +77,7 @@ function Read-ChocoLog {
             $currentSession = $parsed | Where-Object { $_.Thread -eq $threadMatch }
           } else {
             # We haven't seen this thread before, let's make a new object
+            $detected.Add($threadMatch) > $null
             $currentSession = [ChocoLog]::new(
               $threadMatch,
               ($m.Groups['date'].Value -replace ',', '.'),

--- a/docs/en-US/Read-ChocoLog.md
+++ b/docs/en-US/Read-ChocoLog.md
@@ -14,6 +14,7 @@ Parses a Chocolatey log into an object that is easier to search and filter.
 
 ```
 Read-ChocoLog [[-Path] <String[]>] [[-FileLimit] <Int32>] [[-Filter] <String>] [[-PatternLayout] <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -98,6 +99,9 @@ Default value: %date %thread [%-5level] - %message
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,8 @@ theme: readthedocs
 nav:
   - Home: 'index.md'
   - Changelog: 'https://github.com/HeyItsGilbert/ChocoLogParse/blob/main/CHANGELOG.md'
-  - en-US/
+  - en-US:
+      - en-US/
 plugins:
   - search
   - include_dir_to_nav

--- a/tests/Read-ChocoLog.tests.ps1
+++ b/tests/Read-ChocoLog.tests.ps1
@@ -45,9 +45,9 @@ SkipPackageInstallProvider='False'|SkipHookScripts='False'|
 Chocolatey upgraded 0/1 packages.
   See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
 2023-06-14 14:22:10,115 57332 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
-2023-06-14 14:22:10,117 57332 [DEBUG] - Exiting with 100
 2023-06-14 14:22:09,410 12345 [DEBUG] - The source '' evaluated to a 'normal' source type
 2023-06-14 14:22:09,410 54321 [DEBUG] - The source '' evaluated to a 'normal' source type
+2023-06-14 14:22:10,117 57332 [DEBUG] - Exiting with 100
 '@
     # Create 10 files with 2 random sessions
     0..10 | ForEach-Object {
@@ -94,7 +94,7 @@ Chocolatey upgraded 0/1 packages.
     }
 
     It 'Has Configuration with Subkeys' {
-      $parsed.Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
+      $parsed[0].Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
     }
   }
 

--- a/tests/Read-ChocoLog.tests.ps1
+++ b/tests/Read-ChocoLog.tests.ps1
@@ -33,6 +33,7 @@ HelpRequested='False'|UnsuccessfulParsing='False'|RegularOutput='True'|
 QuietOutput='False'|PromptForConfirmation='False'|
 DisableCompatibilityChecks='False'|AcceptLicense='True'|
 AllowUnofficialBuild='False'|Input='zoom'|AllVersions='False'|
+Features.AllowEmptyChecksums='False'|Features.UsePackageExitCodes='True'|
 SkipPackageInstallProvider='False'|SkipHookScripts='False'|
 2023-06-14 14:22:09,418 57332 [DEBUG] - _ Chocolatey:ChocolateyUpgradeCommand - Normal Run Mode _
 2023-06-14 14:22:09,422 57332 [INFO ] - Upgrading the following packages:
@@ -90,6 +91,10 @@ Chocolatey upgraded 0/1 packages.
 
     It 'Detects the right session number' {
       $parsed[0].thread | Should -Be 57332
+    }
+
+    It 'Has Configuration with Subkeys' {
+      $parsed.Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
     }
   }
 


### PR DESCRIPTION
Configuration values had extra quotes around it. Also took this as a chance to make the configuration property support subkeys. This should make it easier to filter on those properties.

This also addresses the issue of multiple threads writing logs simultaneously. 

Corresponding test for both have been added.

## Related Issue
fixes #3 


