### PR TITLE
v1.0.0: Handle Logs with Overlapping Threads

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
         "-Task Test",
         "-Verbose"
       ],
-      "cwd": "${workspaceFolder}"
+      "cwd": "${workspaceFolder}",
+      "createTemporaryIntegratedConsole": true
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,17 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-
     // Start PowerShell (pwsh on *nix)
     "windows": {
         "options": {
             "shell": {
-                "executable": "powershell.exe",
-                "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
+                "executable": "pwsh.exe",
+                "args": [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command"
+                ]
             }
         }
     },
@@ -16,7 +20,10 @@
         "options": {
             "shell": {
                 "executable": "/usr/bin/pwsh",
-                "args": [ "-NoProfile", "-Command" ]
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
             }
         }
     },
@@ -24,11 +31,13 @@
         "options": {
             "shell": {
                 "executable": "/usr/local/bin/pwsh",
-                "args": [ "-NoProfile", "-Command" ]
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
             }
         }
     },
-
     "tasks": [
         {
             "label": "Clean",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.0] Handle Logs with Out of Order Threads
+
+### Added
+
+- Bump Log4NetParse dependency to 1.1.1 which handles threads better.
+- Add TypeAccelerator for ChocoLog
+
+## Removed
+
+- Logs no longer returned for Log4NetLog format. It was suggested that
+  this was noisy.
+
+### Fixes
+
+- Handle when logs that have thread lines that overlap.
+- Fix tests to handle logs dates and ordering.
+
 ## [0.5.0] Add Get-ChocoLogEntry
 
 - Add a new cmdlet that grabs the latest log.

--- a/ChocoLogParse/ChocoLog.format.ps1xml
+++ b/ChocoLogParse/ChocoLog.format.ps1xml
@@ -23,9 +23,6 @@
           <TableColumnHeader>
             <Label>Command Line</Label>
           </TableColumnHeader>
-          <TableColumnHeader>
-            <Label>Log Lines</Label>
-          </TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
@@ -51,9 +48,6 @@
                 <ScriptBlock>
                 [String]::Format("{0}", ($_.cli -replace '"C:\\ProgramData\\chocolatey\\choco.exe"', 'choco'))
                 </ScriptBlock>
-              </TableColumnItem>
-              <TableColumnItem>
-                <PropertyName>logs</PropertyName>
               </TableColumnItem>
             </TableColumnItems>
             <Wrap/>

--- a/ChocoLogParse/ChocoLogParse.psd1
+++ b/ChocoLogParse/ChocoLogParse.psd1
@@ -12,7 +12,7 @@
   RootModule = 'ChocoLogParse.psm1'
 
   # Version number of this module.
-  ModuleVersion = '0.5.0'
+  ModuleVersion = '1.0.0'
 
   # Supported PSEditions
   # CompatiblePSEditions = @()
@@ -24,7 +24,7 @@
   Author = 'Gilbert Sanchez'
 
   # Company or vendor of this module
-  CompanyName = 'Unknown'
+  CompanyName = 'Gilbert Sanchez'
 
   # Copyright statement for this module
   Copyright = '(c) Gilbert Sanchez. All rights reserved.'
@@ -51,7 +51,7 @@
   # ProcessorArchitecture = ''
 
   # Modules that must be imported into the global environment prior to importing this module
-  RequiredModules = @(@{ModuleName = "Log4NetParse"; ModuleVersion = "0.3.0"; })
+  RequiredModules = @(@{ModuleName = "Log4NetParse"; ModuleVersion = "1.1.1"; })
 
   # Assemblies that must be loaded prior to importing this module
   # RequiredAssemblies = @()

--- a/ChocoLogParse/ChocoLogParse.psm1
+++ b/ChocoLogParse/ChocoLogParse.psm1
@@ -15,3 +15,42 @@ $format = Join-Path -Path $PSScriptRoot -ChildPath 'ChocoLog.format.ps1xml'
 Update-FormatData -PrependPath $format
 
 Export-ModuleMember -Function $public.Basename
+
+# This module is combined. Any code in this file as added to the very end.
+
+# Define the types to export with type accelerators.
+$ExportableTypes = @(
+  [ChocoLog]
+)
+# Get the internal TypeAccelerators class to use its static methods.
+$TypeAcceleratorsClass = [psobject].Assembly.GetType(
+  'System.Management.Automation.TypeAccelerators'
+)
+# Ensure none of the types would clobber an existing type accelerator.
+# If a type accelerator with the same name exists, throw an exception.
+$ExistingTypeAccelerators = $TypeAcceleratorsClass::Get
+foreach ($Type in $ExportableTypes) {
+  if ($Type.FullName -in $ExistingTypeAccelerators.Keys) {
+    $Message = @(
+      "Unable to register type accelerator '$($Type.FullName)'"
+      'Accelerator already exists.'
+    ) -join ' - '
+
+    throw [System.Management.Automation.ErrorRecord]::new(
+      [System.InvalidOperationException]::new($Message),
+      'TypeAcceleratorAlreadyExists',
+      [System.Management.Automation.ErrorCategory]::InvalidOperation,
+      $Type.FullName
+    )
+  }
+}
+# Add type accelerators for every exportable type.
+foreach ($Type in $ExportableTypes) {
+  [void]$TypeAcceleratorsClass::Add($Type.FullName, $Type)
+}
+# Remove type accelerators when the module is removed.
+$MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
+  foreach ($Type in $ExportableTypes) {
+    [void]$TypeAcceleratorsClass::Remove($Type.FullName)
+  }
+}.GetNewClosure()

--- a/ChocoLogParse/Classes/ChocoLog.ps1
+++ b/ChocoLogParse/Classes/ChocoLog.ps1
@@ -1,24 +1,20 @@
 using module Log4NetParse
 
 class ChocoLog : Log4NetLog {
-  [string]$cli
-  [string]$exitCode
-  [LogType]$logType
+  [string]$CLI
+  [string]$ExitCode
+  [LogType]$LogType
   [hashtable]$Configuration
 
   ChocoLog(
     [int]$Thread,
-    [datetime]$startTime,
     [string]$filePath
   ) : base (
     $Thread,
-    $startTime,
     $filePath
   ) {
-    $this.thread = $Thread
-    $this.startTime = $startTime
-    $this.logs = [System.Collections.Generic.List[Log4NetLogLine]]::new()
-    $this.filePath = $filePath
+    $this.Thread = $Thread
+    $this.FilePath = $filePath
     $this.Configuration = @{}
     if ($filePath -like "*summary*") {
       $this.logType = [LogType]::Summary
@@ -30,10 +26,12 @@ class ChocoLog : Log4NetLog {
   # This parses all the logs for entries that are part of the class
   [void] ParseSpecialLogs() {
     # Set the end time here since we are done parsing
-    $this.endTime = $this.logs[-1].time
+    $this._logs.Sort()
+    $this.StartTime = $this._logs[0].time
+    $this.EndTime = $this._logs[-1].time
 
     # Detect known patterns
-    $this.logs | ForEach-Object {
+    $this._logs | ForEach-Object {
       switch ($_.message) {
         { $_.StartsWith('Command line: ') } { $this.SetCli($_) }
         { $_.StartsWith('Exiting with ') } { $this.SetExitCode($_) }
@@ -42,7 +40,6 @@ class ChocoLog : Log4NetLog {
         }
         Default {}
       }
-
     }
   }
 

--- a/docs/en-US/Get-ChocoLogEntry.md
+++ b/docs/en-US/Get-ChocoLogEntry.md
@@ -15,7 +15,7 @@ Defaults to last exection.
 
 ```
 Get-ChocoLogEntry [[-Path] <String[]>] [[-Filter] <String>] [[-PatternLayout] <String>] [-Report]
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -88,6 +88,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-ChocoLogEntry.md
+++ b/docs/en-US/Get-ChocoLogEntry.md
@@ -1,7 +1,7 @@
 ---
 external help file: ChocoLogParse-help.xml
 Module Name: ChocoLogParse
-online version: https://heyitsgilbert.github.io/ChocoLogParse/en-US/Get-ChocoLogEntry/
+online version:
 schema: 2.0.0
 ---
 
@@ -33,7 +33,9 @@ Grabs the laste entry from the latest log
 ## PARAMETERS
 
 ### -Path
-{{ Fill Path Description }}
+The log path you want to parse.
+This will default to the latest local log.
+This can be a directory of logs.
 
 ```yaml
 Type: String[]
@@ -48,7 +50,8 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-{{ Fill Filter Description }}
+The filter passed to Get Child Item.
+Default to 'chocolatey*.log.'
 
 ```yaml
 Type: String
@@ -63,7 +66,11 @@ Accept wildcard characters: False
 ```
 
 ### -PatternLayout
-{{ Fill PatternLayout Description }}
+The log4net pattern layout used to parse the log.
+It is very unlikely that you
+need to supply this.
+The code expects pattern names: time, session, level, and
+message.
 
 ```yaml
 Type: String
@@ -119,6 +126,3 @@ Works for Windows PowerShell and PowerShell Core (e.g.
 7).
 
 ## RELATED LINKS
-
-[https://heyitsgilbert.github.io/ChocoLogParse/en-US/Get-ChocoLogEntry/](https://heyitsgilbert.github.io/ChocoLogParse/en-US/Get-ChocoLogEntry/)
-

--- a/docs/en-US/Read-ChocoLog.md
+++ b/docs/en-US/Read-ChocoLog.md
@@ -45,7 +45,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: C:\ProgramData\chocolatey\logs\
+Default value: "$($env:ChocolateyInstall)\logs\"
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -107,7 +107,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Collections.ArrayList
+### System.Collections.Generic.List`1[[ChocoLog, PowerShell Class Assembly, Version=1.0.0.3, Culture=neutral, PublicKeyToken=null]]
 ## NOTES
 Works for Windows PowerShell and PowerShell Core.
 This works on Linux.

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '5.5.0'
+        Version = '5.6.1'
         Parameters = @{
             SkipPublisherCheck = $true
         }

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -21,6 +21,6 @@
         Version = '1.19.1'
     }
     'Log4NetParse' = @{
-        Version = '0.4.0'
+        Version = '1.1.1'
     }
 }

--- a/tests/ChocoLogParse.tests.ps1
+++ b/tests/ChocoLogParse.tests.ps1
@@ -46,11 +46,11 @@ Chocolatey upgraded 0/1 packages.
 2023-06-14 14:22:10,115 57332 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
 2023-06-14 14:22:10,116 57332 [DEBUG] - Exiting with 100
 2023-06-14 14:22:09,410 12345 [DEBUG] - The source '' evaluated to a 'normal' source type
-2023-06-14 15:22:09,411 54321 [DEBUG] - .
+2023-06-14 14:22:09,411 54321 [DEBUG] - .
 NOTE: Hiding sensitive configuration data! Please double and triple
   check to be sure no sensitive data is shown, especially if copying
   output to a gist for review.
-2023-06-14 15:22:09,417 54321 [DEBUG] - Configuration: CommandName='upgrade'|CacheLocation='C:\Windows\TEMP\chocolatey'|
+2023-06-14 14:22:09,417 54321 [DEBUG] - Configuration: CommandName='upgrade'|CacheLocation='C:\Windows\TEMP\chocolatey'|
 ContainsLegacyPackageInstalls='False'|
 CommandExecutionTimeoutSeconds='2700'|WebRequestTimeoutSeconds='30'|
 Sources=''|SourceType='normal'|
@@ -61,17 +61,17 @@ DisableCompatibilityChecks='False'|AcceptLicense='True'|
 AllowUnofficialBuild='False'|Input='zoom'|AllVersions='False'|
 Features.AllowEmptyChecksums='False'|Features.UsePackageExitCodes='True'|
 SkipPackageInstallProvider='False'|SkipHookScripts='False'|
-2023-06-14 15:22:09,418 54321 [DEBUG] - _ Chocolatey:ChocolateyUpgradeCommand - Normal Run Mode _
-2023-06-14 15:22:09,422 54321 [INFO ] - Upgrading the following packages:
-2023-06-14 15:22:09,423 54321 [INFO ] - zoom
-2023-06-14 15:22:09,423 54321 [INFO ] - By upgrading, you accept licenses for the packages.
-2023-06-14 15:22:10,107 54321 [INFO ] - zoom v5.14.11.17466 is newer than the most recent.
+2023-06-14 14:22:09,418 54321 [DEBUG] - _ Chocolatey:ChocolateyUpgradeCommand - Normal Run Mode _
+2023-06-14 14:22:09,422 54321 [INFO ] - Upgrading the following packages:
+2023-06-14 14:22:09,423 54321 [INFO ] - zoom
+2023-06-14 14:22:09,423 54321 [INFO ] - By upgrading, you accept licenses for the packages.
+2023-06-14 14:22:10,107 54321 [INFO ] - zoom v5.14.11.17466 is newer than the most recent.
   You must be smarter than the average bear...
-2023-06-14 15:22:10,113 54321 [WARN ] - .
+2023-06-14 14:22:10,113 54321 [WARN ] - .
 Chocolatey upgraded 0/1 packages.
   See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
-2023-06-14 15:22:10,115 54321 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
-2023-06-14 15:22:10,117 54321 [DEBUG] - Exiting with 900
+2023-06-14 14:22:10,115 54321 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
+2023-06-14 14:22:10,117 54321 [DEBUG] - Exiting with 900
 '@
   # Create 10 files with 2 random sessions
   0..10 | ForEach-Object {
@@ -139,7 +139,7 @@ Describe 'Read-ChocoLog' {
     }
 
     It 'Parses the correct number of lines per session' {
-      $multiple[1].logs.Count | Should -Be 9
+      $multiple[0].logs.Count | Should -Be 9
     }
   }
 }
@@ -179,14 +179,7 @@ Describe 'Get-ChocoLogEntry' {
     }
 
     It 'Parses the correct number of lines per session' {
-      $multiple.logs.Count | Should -Be 9
-    }
-  }
-  Context "Test known fixtures" {
-    It 'Parses log with out of order threads' {
-      $results = Read-Log4NetLog "$PSScriptRoot\fixtures\ch.log"
-      $results.Count | Should -Be 4
-      $results.Thread | Should -Be @(12720, 6432, 18380, 14068)
+      $multiple.logs.Count | Should -Be 2
     }
   }
 }

--- a/tests/ChocoLogParse.tests.ps1
+++ b/tests/ChocoLogParse.tests.ps1
@@ -46,11 +46,11 @@ Chocolatey upgraded 0/1 packages.
 2023-06-14 14:22:10,115 57332 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
 2023-06-14 14:22:10,116 57332 [DEBUG] - Exiting with 100
 2023-06-14 14:22:09,410 12345 [DEBUG] - The source '' evaluated to a 'normal' source type
-2023-06-14 14:22:09,411 54321 [DEBUG] - .
+2023-06-14 15:22:09,411 54321 [DEBUG] - .
 NOTE: Hiding sensitive configuration data! Please double and triple
   check to be sure no sensitive data is shown, especially if copying
   output to a gist for review.
-2023-06-14 14:22:09,417 54321 [DEBUG] - Configuration: CommandName='upgrade'|CacheLocation='C:\Windows\TEMP\chocolatey'|
+2023-06-14 15:22:09,417 54321 [DEBUG] - Configuration: CommandName='upgrade'|CacheLocation='C:\Windows\TEMP\chocolatey'|
 ContainsLegacyPackageInstalls='False'|
 CommandExecutionTimeoutSeconds='2700'|WebRequestTimeoutSeconds='30'|
 Sources=''|SourceType='normal'|
@@ -61,17 +61,17 @@ DisableCompatibilityChecks='False'|AcceptLicense='True'|
 AllowUnofficialBuild='False'|Input='zoom'|AllVersions='False'|
 Features.AllowEmptyChecksums='False'|Features.UsePackageExitCodes='True'|
 SkipPackageInstallProvider='False'|SkipHookScripts='False'|
-2023-06-14 14:22:09,418 54321 [DEBUG] - _ Chocolatey:ChocolateyUpgradeCommand - Normal Run Mode _
-2023-06-14 14:22:09,422 54321 [INFO ] - Upgrading the following packages:
-2023-06-14 14:22:09,423 54321 [INFO ] - zoom
-2023-06-14 14:22:09,423 54321 [INFO ] - By upgrading, you accept licenses for the packages.
-2023-06-14 14:22:10,107 54321 [INFO ] - zoom v5.14.11.17466 is newer than the most recent.
+2023-06-14 15:22:09,418 54321 [DEBUG] - _ Chocolatey:ChocolateyUpgradeCommand - Normal Run Mode _
+2023-06-14 15:22:09,422 54321 [INFO ] - Upgrading the following packages:
+2023-06-14 15:22:09,423 54321 [INFO ] - zoom
+2023-06-14 15:22:09,423 54321 [INFO ] - By upgrading, you accept licenses for the packages.
+2023-06-14 15:22:10,107 54321 [INFO ] - zoom v5.14.11.17466 is newer than the most recent.
   You must be smarter than the average bear...
-2023-06-14 14:22:10,113 54321 [WARN ] - .
+2023-06-14 15:22:10,113 54321 [WARN ] - .
 Chocolatey upgraded 0/1 packages.
   See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
-2023-06-14 14:22:10,115 54321 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
-2023-06-14 14:22:10,117 54321 [DEBUG] - Exiting with 900
+2023-06-14 15:22:10,115 54321 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
+2023-06-14 15:22:10,117 54321 [DEBUG] - Exiting with 900
 '@
   # Create 10 files with 2 random sessions
   0..10 | ForEach-Object {
@@ -109,19 +109,19 @@ Describe 'Read-ChocoLog' {
     }
 
     It 'Parses the correct number of lines per session' {
-      $parsed[0].logs.Count | Should -Be 10
+      $parsed[1].logs.Count | Should -Be 10
     }
 
     It 'Detects the exit code' {
-      $parsed[0].exitCode | Should -Be 100
+      $parsed[1].exitCode | Should -Be 100
     }
 
     It 'Detects the right session number' {
-      $parsed[0].thread | Should -Be 57332
+      $parsed[1].thread | Should -Be 57332
     }
 
     It 'Has Configuration with Subkeys' {
-      $parsed[0].Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
+      $parsed[1].Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
     }
   }
 
@@ -139,7 +139,7 @@ Describe 'Read-ChocoLog' {
     }
 
     It 'Parses the correct number of lines per session' {
-      $multiple[0].logs.Count | Should -Be 9
+      $multiple[1].logs.Count | Should -Be 9
     }
   }
 }
@@ -179,7 +179,14 @@ Describe 'Get-ChocoLogEntry' {
     }
 
     It 'Parses the correct number of lines per session' {
-      $multiple.logs.Count | Should -Be 2
+      $multiple.logs.Count | Should -Be 9
+    }
+  }
+  Context "Test known fixtures" {
+    It 'Parses log with out of order threads' {
+      $results = Read-Log4NetLog "$PSScriptRoot\fixtures\ch.log"
+      $results.Count | Should -Be 4
+      $results.Thread | Should -Be @(12720, 6432, 18380, 14068)
     }
   }
 }

--- a/tests/ChocoLogParse.tests.ps1
+++ b/tests/ChocoLogParse.tests.ps1
@@ -146,40 +146,40 @@ Describe 'Read-ChocoLog' {
 
 Describe 'Get-ChocoLogEntry' {
   BeforeAll {
-    $parsed = Get-ChocoLogEntry -Path $singleFile
-    $multiple = Get-ChocoLogEntry -Path $folder
+    $parsedEntry = Get-ChocoLogEntry -Path $singleFile
+    $multipleEntry = Get-ChocoLogEntry -Path $folder
   }
 
   Context 'For Single File' {
     It 'Parses the correct number of sessions' {
-        ($parsed).Count | Should -Be 1
+        ($parsedEntry).Count | Should -Be 1
     }
 
     It 'Parses the correct number of lines per session' {
-      $parsed.logs.Count | Should -Be 10
+      $parsedEntry.logs.Count | Should -Be 10
     }
 
     It 'Detects the exit code' {
-      $parsed.exitCode | Should -Be 900
+      $parsedEntry.exitCode | Should -Be 900
     }
 
     It 'Detects the right session number' {
-      $parsed.thread | Should -Be 54321
+      $parsedEntry.thread | Should -Be 54321
     }
 
     It 'Has Configuration with Subkeys' {
-      $parsed.Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
+      $parsedEntry.Configuration['Features']['UsePackageExitCodes'] | Should -Be 'True'
     }
   }
 
   Context 'For Folder Path' {
     It 'Parses the correct default number of sessions' {
       # Should still only return 1 regardless of folder
-      ($multiple).Count | Should -Be 1
+      ($multipleEntry).Count | Should -Be 1
     }
 
     It 'Parses the correct number of lines per session' {
-      $multiple.logs.Count | Should -Be 2
+      $multipleEntry.logs.Count | Should -Be 2
     }
   }
 }

--- a/tests/fixtures/ch.log
+++ b/tests/fixtures/ch.log
@@ -1,0 +1,223 @@
+2024-07-03 06:44:28,288 14068 [DEBUG] - Cache Folder Lockdown Checks:
+2024-07-03 06:44:28,289 14068 [DEBUG] -  - Elevated State = Failed
+2024-07-03 06:44:28,304 14068 [DEBUG] - The source 'https://licensedpackages.chocolatey.org/api/v2/;https://community.chocolatey.org/api/v2/;REDACTED' evaluated to a 'normal' source type
+2024-07-03 06:44:28,627 14068 [DEBUG] -
+NOTE: Hiding sensitive configuration data! Please double and triple
+ check to be sure no sensitive data is shown, especially if copying
+ output to a gist for review.
+2024-07-03 06:44:28,640 14068 [DEBUG] - Configuration: MaximumDownloadRateBitsPerSecond='0'|
+MaximumDownloadRateBitsPerSecondAutoSet='False'|
+LicensedInformation.LicenseType='Business'|
+LicensedInformation.LicenseIsValid='True'|
+LicensedInformation.LicenseIsTrial='False'|
+LicensedInformation.PauseInTrial='False'|
+LicensedInformation.LicenseUserName='Chocolatey Software, Inc. [100] (cory[at REDACTED])'|
+
+LicensedInformation.LicenseExpirationDate='2026-06-30 12:00:00 AM'|
+LicensedInformation.LicenseNodeCount='100'|
+LicensedInformation.LicensedVersion='6.2.1.0'|
+ChocolateyVersion.Version='2.3.0.0'|
+ChocolateyVersion.IsLegacyVersion='False'|
+ChocolateyVersion.Revision='0'|ChocolateyVersion.IsSemVer2='False'|
+ChocolateyVersion.OriginalVersion='2.3.0.0'|
+ChocolateyVersion.Major='2'|
+ChocolateyVersion.Minor='3'|ChocolateyVersion.Patch='0'|
+ChocolateyVersion.IsPrerelease='False'|
+ChocolateyVersion.HasMetadata='False'|
+LicensedFeatures.UseDownloadCache='True'|
+LicensedFeatures.AllowSynchronization='True'|
+LicensedFeatures.AllowBackgroundServiceOverride='False'|
+LicensedFeatures.UseBackgroundService='False'|
+LicensedFeatures.UseBackgroundServiceWithSelfServiceSourcesOnly='True'|
+LicensedFeatures.UseBackgroundServiceWithNonAdministratorsOnly='False'|
+LicensedFeatures.UseBackgroundServiceInteractively='False'|
+LicensedFeatures.UseBackgroundServiceWithEmptySessions='True'|
+LicensedFeatures.AllowBackgroundServiceUninstallsFromUserInstallsOnly='False'|
+
+LicensedFeatures.AllowPreviewFeatures='True'|
+LicensedFeatures.ShowAllPackagesInProgramsAndFeatures='False'|
+LicensedFeatures.AdminOnlyExecutionForAllChocolateyCommands='False'|
+LicensedFeatures.AdminOnlyExecutionForNewCommand='False'|
+LicensedFeatures.AdminOnlyExecutionForDownloadCommand='False'|
+LicensedFeatures.ReduceInstalledPackageSize='True'|
+LicensedFeatures.ReduceOnlyNupkgSize='False'|
+LicensedFeatures.UseLocalSystemForServiceInstalls='True'|
+LicensedFeatures.WarnOnUpcomingLicenseExpiration='True'|
+LicensedFeatures.UseChocolateyCentralManagement='False'|
+LicensedFeatures.UseChocolateyCentralManagementDeployments='False'|
+LicensedFeatures.UseLogRetentionPolicy='True'|
+LicensedFeatures.ExcludeChocolateyPackagesDuringUpgradeAll='False'|
+LicensedNewCommand.UseOriginalFilesLocation='False'|
+LicensedNewCommand.PauseOnError='False'|
+LicensedNewCommand.BuildPackage='False'|
+LicensedNewCommand.GeneratePackagesFromSoftwareInstalls='False'|
+LicensedNewCommand.IncludeArchitectureInPackageId='False'|
+LicensedDownloadCommand.Internalize='False'|
+LicensedDownloadCommand.AppendUseOriginalLocation='True'|
+LicensedDownloadCommand.InternalizeAnyUrlFound='False'|
+LicensedDownloadCommand.DownloadInstalledPackages='False'|
+LicensedDownloadCommand.IgnoreUnfoundPackages='False'|
+LicensedConvertCommand.IncludeAll='False'|
+LicensedConvertCommand.IncludeDependencies='False'|
+LicensedPushCommand.IntuneAuthenticationUrl='https://login.microsoftonline.com'|
+
+LicensedPushCommand.IntuneApiUrl='https://graph.microsoft.com'|
+LicensedPushCommand.IntuneRetryIntervalInSeconds='5'|
+LicensedPushCommand.IntuneUploadTimeoutInSeconds='600'|
+LicensedPushCommand.IntuneUploadChunkSizeInMegabytes='10'|
+LicensedPushCommand.SkipCleanup='False'|
+LicensedListCommand.ShowAuditInformation='False'|
+LicensedListCommand.ShowDisplayVersion='False'|
+LicensedUninstallCommand.FromProgramsAndFeatures='False'|
+VirusConfiguration.VirusCheckMinimumPositives='4'|
+VirusConfiguration.VirusScannerType='Generic'|
+VirusConfiguration.GenericVirusScannerArgs=''[[File]]''|
+VirusConfiguration.GenericVirusScannerValidExitCodes='0'|
+VirusConfiguration.GenericVirusScannerTimeoutInSeconds='120'|
+LicensedServiceInstaller.DefaultUserName='ChocolateyLocalAdmin'|
+CentralManagementConfiguration.ReportPackagesTimerIntervalInSeconds='1800'|
+
+CentralManagementConfiguration.ReceiveTimeoutInSeconds='30'|
+CentralManagementConfiguration.SendTimeoutInSeconds='30'|
+CentralManagementConfiguration.CertificateValidationMode='PeerOrChainTrust'|
+
+CentralManagementConfiguration.MaxReceiveMessageSizeInBytes='2147483647'|
+
+CentralManagementConfiguration.DeploymentCheckTimerIntervalInSeconds='180'|
+
+LicensedBackgroundService.LogRetentionPolicyInDays='30'|
+CommandName='pack'|
+CacheLocation='C:\Users\corbob\AppData\Local\Temp\chocolatey'|
+CommandExecutionTimeoutSeconds='2700'|WebRequestTimeoutSeconds='30'|
+Sources='https://licensedpackages.chocolatey.org/api/v2/;https://community.chocolatey.org/api/v2/;REDACTED'|
+
+SourceType='normal'|IncludeConfiguredSources='False'|
+ShowOnlineHelp='False'|Debug='False'|Verbose='False'|Trace='False'|
+Force='False'|Noop='False'|HelpRequested='False'|
+UnsuccessfulParsing='False'|RegularOutput='False'|QuietOutput='False'|
+PromptForConfirmation='False'|DisableCompatibilityChecks='False'|
+AcceptLicense='False'|AllowUnofficialBuild='False'|AllVersions='False'|
+SkipPackageInstallProvider='False'|SkipHookScripts='False'|
+Prerelease='False'|ForceX86='False'|OverrideArguments='False'|
+NotSilent='False'|ApplyPackageParametersToDependencies='False'|
+ApplyInstallArgumentsToDependencies='False'|IgnoreDependencies='False'|
+CacheExpirationInMinutes='30'|AllowDowngrade='False'|
+ForceDependencies='False'|PinPackage='False'|
+Information.PlatformType='Windows'|
+Information.PlatformVersion='10.0.19045.0'|
+Information.PlatformName='Windows 10'|
+Information.ChocolateyVersion='2.3.0.0'|
+Information.ChocolateyProductVersion='2.3.0'|
+Information.FullName='choco, Version=2.3.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb'|
+
+Information.Is64BitOperatingSystem='True'|
+Information.Is64BitProcess='True'|Information.IsInteractive='True'|
+Information.UserName='corbob'|
+Information.UserDomainName='CORBOB-MACBOOK'|
+Information.IsUserAdministrator='True'|
+Information.IsUserSystemAccount='False'|
+Information.IsUserRemoteDesktop='False'|
+Information.IsUserRemote='False'|Information.IsProcessElevated='False'|
+Information.IsLicensedVersion='True'|
+Information.IsLicensedAssemblyLoaded='True'|
+Information.LicenseType='Business'|
+Information.CurrentDirectory='C:\Users\corbob\AppData\Local\Temp\c4a2a6b5-c1d3-47f2-835a-6db4aea906fe\packages\test_package_1'|
+
+Features.AutoUninstaller='True'|Features.ChecksumFiles='True'|
+Features.AllowEmptyChecksums='False'|
+Features.AllowEmptyChecksumsSecure='True'|
+Features.FailOnAutoUninstaller='False'|
+Features.FailOnStandardError='False'|Features.UsePowerShellHost='True'|
+Features.LogEnvironmentValues='False'|Features.LogWithoutColor='False'|
+Features.VirusCheck='False'|
+Features.FailOnInvalidOrMissingLicense='False'|
+Features.IgnoreInvalidOptionsSwitches='True'|
+Features.UsePackageExitCodes='True'|
+Features.UseEnhancedExitCodes='False'|
+Features.UseFipsCompliantChecksums='False'|
+Features.ShowNonElevatedWarnings='True'|
+Features.ShowDownloadProgress='True'|
+Features.StopOnFirstPackageFailure='False'|
+Features.UseRememberedArgumentsForUpgrades='False'|
+Features.IgnoreUnfoundPackagesOnUpgradeOutdated='False'|
+Features.SkipPackageUpgradesWhenNotInstalled='False'|
+Features.RemovePackageInformationOnUninstall='False'|
+Features.ExitOnRebootDetected='False'|
+Features.LogValidationResultsOnWarnings='True'|
+Features.UsePackageRepositoryOptimizations='True'|
+Features.UsePackageHashValidation='False'|
+ListCommand.LocalOnly='False'|
+ListCommand.IdOnly='False'|ListCommand.IncludeRegistryPrograms='False'|
+ListCommand.PageSize='25'|ListCommand.Exact='False'|
+ListCommand.ByIdOnly='False'|ListCommand.ByTagOnly='False'|
+ListCommand.IdStartsWith='False'|ListCommand.OrderByPopularity='False'|
+ListCommand.ApprovedOnly='False'|
+ListCommand.DownloadCacheAvailable='False'|
+ListCommand.NotBroken='False'|
+ListCommand.IncludeVersionOverrides='False'|
+ListCommand.ExplicitPageSize='False'|
+ListCommand.ExplicitSource='False'|
+UpgradeCommand.FailOnUnfound='False'|
+UpgradeCommand.FailOnNotInstalled='False'|
+UpgradeCommand.NotifyOnlyAvailableUpgrades='False'|
+UpgradeCommand.ExcludePrerelease='False'|
+UpgradeCommand.IgnorePinned='False'|
+NewCommand.AutomaticPackage='False'|
+NewCommand.UseOriginalTemplate='False'|SourceCommand.Command='unknown'|
+SourceCommand.Priority='0'|SourceCommand.BypassProxy='False'|
+SourceCommand.AllowSelfService='False'|
+SourceCommand.VisibleToAdminsOnly='False'|
+FeatureCommand.Command='unknown'|ConfigCommand.Command='Unknown'|
+ApiKeyCommand.Command='Unknown'|
+PushCommand.DefaultSource='https://push.chocolatey.org/'|
+PinCommand.Command='Unknown'|OutdatedCommand.IgnorePinned='False'|
+ExportCommand.IncludeVersionNumbers='False'|Proxy.BypassOnLocal='True'|
+TemplateCommand.Command='unknown'|CacheCommand.Command='Unknown'|
+CacheCommand.RemoveExpiredItemsOnly='False'|
+2024-07-03 06:44:28,641 14068 [DEBUG] - _ Chocolatey:ChocolateyPackCommand - Normal Run Mode _
+2024-07-03 06:44:28,865 14068 [INFO ] - Attempting to build package from 'test_package_1.nuspec'.
+2024-07-03 06:44:28,998 14068 [INFO ] - Successfully created package 'C:\Users\corbob\AppData\Local\Temp\c4a2a6b5-c1d3-47f2-835a-6db4aea906fe\packages\test_package_1\test_package_1.1.3.0.nupkg'
+2024-07-03 06:44:29,000 14068 [DEBUG] - Sending message 'PostRunMessage' out if there are subscribers...
+2024-07-03 06:44:29,002 14068 [DEBUG] - [Countdown] Determining how long until license expires
+2024-07-03 06:44:29,004 14068 [DEBUG] - Exiting with 0
+2024-07-03 06:44:46,011 18380 [DEBUG] - XmlConfiguration is now operational
+2024-07-03 06:44:46,031 18380 [DEBUG] - Evaluating license file found at 'C:\ProgramData\chocolatey\license\chocolatey.license.xml'
+2024-07-03 06:44:46,499 6432 [DEBUG] - XmlConfiguration is now operational
+2024-07-03 06:44:46,520 6432 [DEBUG] - Evaluating license file found at 'C:\ProgramData\chocolatey\license\chocolatey.license.xml'
+2024-07-03 06:44:46,630 18380 [DEBUG] - Loading up 'chocolatey.licensed' assembly type from 'C:\ProgramData\chocolatey\extensions\chocolatey\chocolatey.licensed.dll'
+2024-07-03 06:44:46,634 18380 [DEBUG] - Minimum Chocolatey Version: '2.0.0'
+2024-07-03 06:44:46,637 18380 [DEBUG] - Current Chocolatey Version: '2.3.0.0'
+2024-07-03 06:44:46,638 18380 [DEBUG] - Current Chocolatey Licensed Version: '6.2.1.0'
+2024-07-03 06:44:46,664 18380 [DEBUG] - Adding new type 'CygwinService' for type 'IAlternativeSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,665 18380 [DEBUG] - Adding new type 'CygwinService' for type 'IInstallSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,666 18380 [DEBUG] - Adding new type 'PythonService' for type 'IAlternativeSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,667 18380 [DEBUG] - Adding new type 'PythonService' for type 'IListSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,667 18380 [DEBUG] - Adding new type 'PythonService' for type 'IInstallSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,668 18380 [DEBUG] - Adding new type 'PythonService' for type 'IUninstallSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,669 18380 [DEBUG] - Adding new type 'RubyGemsService' for type 'IAlternativeSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,670 18380 [DEBUG] - Adding new type 'RubyGemsService' for type 'IListSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,670 18380 [DEBUG] - Adding new type 'RubyGemsService' for type 'IInstallSourceRunner' from assembly 'choco'
+2024-07-03 06:44:46,672 18380 [DEBUG] - Adding new type 'SystemStateValidation' for type 'IValidation' from assembly 'choco'
+2024-07-03 06:44:46,673 18380 [DEBUG] - Adding new type 'CacheFolderLockdownValidation' for type 'IValidation' from assembly 'choco'
+2024-07-03 06:44:46,820 12720 [DEBUG] - XmlConfiguration is now operational
+2024-07-03 06:44:46,837 12720 [DEBUG] - Evaluating license file found at 'C:\ProgramData\chocolatey\license\chocolatey.license.xml'
+2024-07-03 06:44:47,034 18380 [DEBUG] - Adding new type 'EmptyOrInvalidUrlMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,035 18380 [DEBUG] - Adding new type 'FrameWorkReferencesMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,036 18380 [DEBUG] - Adding new type 'IconMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,037 18380 [DEBUG] - Adding new type 'LicenseMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,038 18380 [DEBUG] - Adding new type 'PackageTypesMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,039 18380 [DEBUG] - Adding new type 'ReadmeMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,039 18380 [DEBUG] - Adding new type 'RepositoryMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,040 18380 [DEBUG] - Adding new type 'RequireLicenseAcceptanceMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,041 18380 [DEBUG] - Adding new type 'ServicableMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,042 18380 [DEBUG] - Adding new type 'VersionMetadataRule' for type 'IMetadataRule' from assembly 'choco'
+2024-07-03 06:44:47,047 6432 [DEBUG] - Loading up 'chocolatey.licensed' assembly type from 'C:\ProgramData\chocolatey\extensions\chocolatey\chocolatey.licensed.dll'
+2024-07-03 06:44:47,049 18380 [DEBUG] - Registering new command 'cache' in assembly 'choco'
+2024-07-03 06:44:47,050 18380 [DEBUG] - Registering new command 'list' in assembly 'choco'
+2024-07-03 06:44:47,051 18380 [DEBUG] - Registering new command 'rule' in assembly 'choco'
+2024-07-03 06:44:47,052 18380 [DEBUG] - Registering new command 'template' in assembly 'choco'
+2024-07-03 06:44:47,053 6432 [DEBUG] - Current Chocolatey Version: '2.3.0.0'
+2024-07-03 06:44:47,054 6432 [DEBUG] - Current Chocolatey Licensed Version: '6.2.1.0'
+2024-07-03 06:44:47,058 18380 [DEBUG] - Registering new command 'info' in assembly 'choco'
+2024-07-03 06:44:47,059 18380 [DEBUG] - Registering new command 'help' in assembly 'choco'
+2024-07-03 06:44:47,060 18380 [DEBUG] - Registering new command 'config' in assembly 'choco'


### PR DESCRIPTION

### Added

- Bump Log4NetParse dependency to 1.1.1 which handles threads better.
- Add TypeAccelerator for ChocoLog

## Removed

- Logs no longer returned for Log4NetLog format. It was suggested that
  this was noisy.

### Fixes

- Handle when logs that have thread lines that overlap.
- Fix tests to handle logs dates and ordering.