### PR TITLE
refactor(workflow): standardise publish dispatch inputs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,41 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to publish. Leave empty to use the version in the module manifest."
+        required: false
+        type: string
+      force:
+        description: "If true, bypass the PSGallery version existence check. Use when re-triggering a failed publish job (pattern: force=true, create_release=false, publish=true)."
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: "If true, skip actual publishing and just validate the workflow logic."
+        required: false
+        type: boolean
+        default: false
+      create_release:
+        description: "If false, skip creating the GitHub release and tag."
+        required: false
+        type: boolean
+        default: true
+      publish:
+        description: "If false, skip publishing to PowerShell Gallery."
+        required: false
+        type: boolean
+        default: true
+permissions:
+  contents: write
 jobs:
-  build:
+  publish:
+    name: Publish Module
     uses: HeyItsGilbert/.github/.github/workflows/PublishModule.yml@main
+    with:
+      version: ${{ inputs.version || '' }}
+      force: ${{ inputs.force || false }}
+      dry_run: ${{ inputs.dry_run || false }}
+      create_release: ${{ github.event_name != 'workflow_dispatch' || inputs.create_release }}
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
     secrets: inherit

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '5.6.1'
+        Version = '5.7.1'
         Parameters = @{
             SkipPublisherCheck = $true
         }


### PR DESCRIPTION
Adds full dispatch input surface (`version`, `force`, `dry_run`, `create_release`, `publish`) aligned with HeyItsGilbert/.github#1.

Re-trigger pattern for a failed publish: `force=true, create_release=false, publish=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)